### PR TITLE
pass event while onTouchEnd occurs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ Drag.prototype.onTouchMove = function(e) {
 
 Drag.prototype.onTouchEnd = function(e) {
   var tapped = (e.timeStamp - this.startTime) < this.tapTime;
-  if (tapped) { this.emit('tapped'); }
-  else { this.emit('ended'); }
+  if (tapped) { this.emit('tapped', e); }
+  else { this.emit('ended', e); }
 };
 
 Drag.prototype.move = function(delta) {


### PR DESCRIPTION
- for fixing  Bug 1050545 - [Camera] switching to video mode often sets focus in the lower right.
